### PR TITLE
Refactor exceptions to be DRY

### DIFF
--- a/src/Exceptions/XdgNotAvailableException.php
+++ b/src/Exceptions/XdgNotAvailableException.php
@@ -10,11 +10,11 @@ class XdgNotAvailableException extends RuntimeException
 {
     public static function directoryNotAvailable(string $directoryName): self
     {
-        return new self('Unable to get the XDG ' . $directoryName . ' directory');
+        return new self('Unable to get the XDG '.$directoryName.' directory');
     }
 
     public static function directoriesNotAvailable(string $directoryName): self
     {
-        return new self('Unable to get the XDG ' . $directoryName . ' directories');
+        return new self('Unable to get the XDG '.$directoryName.' directories');
     }
 }

--- a/src/Exceptions/XdgNotAvailableException.php
+++ b/src/Exceptions/XdgNotAvailableException.php
@@ -8,38 +8,13 @@ use RuntimeException;
 
 class XdgNotAvailableException extends RuntimeException
 {
-    public static function homeDirectoryNotAvailable(): self
+    public static function directoryNotAvailable(string $directoryName): self
     {
-        return new self('Unable to get the XDG home directory');
+        return new self('Unable to get the XDG ' . $directoryName . ' directory');
     }
 
-    public static function homeCacheDirectoryNotAvailable(): self
+    public static function directoriesNotAvailable(string $directoryName): self
     {
-        return new self('Unable to get the XDG home cache directory');
-    }
-
-    public static function homeConfigDirectoryNotAvailable(): self
-    {
-        return new self('Unable to get the XDG home config directory');
-    }
-
-    public static function homeDataDirectoryNotAvailable(): self
-    {
-        return new self('Unable to get the XDG home data directory');
-    }
-
-    public static function runtimeDirectoryNotAvailable(): self
-    {
-        return new self('Unable to get the XDG runtime directory');
-    }
-
-    public static function dataDirectoriesNotAvailable(): self
-    {
-        return new self('Unable to get the XDG runtime directory');
-    }
-
-    public static function configDirectoriesNotAvailable(): self
-    {
-        return new self('Unable to get the XDG runtime directory');
+        return new self('Unable to get the XDG ' . $directoryName . ' directories');
     }
 }

--- a/src/Xdg.php
+++ b/src/Xdg.php
@@ -23,7 +23,7 @@ class Xdg
             return $directory;
         }
 
-        throw XdgNotAvailableException::homeDirectoryNotAvailable();
+        throw XdgNotAvailableException::directoryNotAvailable('home');
     }
 
     public function getHomeCacheDirectory(): string
@@ -32,7 +32,7 @@ class Xdg
             return $directory;
         }
 
-        throw XdgNotAvailableException::homeCacheDirectoryNotAvailable();
+        throw XdgNotAvailableException::directoryNotAvailable('home cache');
     }
 
     public function getHomeConfigDirectory(): string
@@ -41,7 +41,7 @@ class Xdg
             return $directory;
         }
 
-        throw XdgNotAvailableException::homeConfigDirectoryNotAvailable();
+        throw XdgNotAvailableException::directoryNotAvailable('home config');
     }
 
     public function getHomeDataDirectory(): string
@@ -50,7 +50,7 @@ class Xdg
             return $directory;
         }
 
-        throw XdgNotAvailableException::homeDataDirectoryNotAvailable();
+        throw XdgNotAvailableException::directoryNotAvailable('home data');
     }
 
     public function getRuntimeDirectory(bool $strict = true): string
@@ -59,7 +59,7 @@ class Xdg
             return $directory;
         }
 
-        throw XdgNotAvailableException::runtimeDirectoryNotAvailable();
+        throw XdgNotAvailableException::directoryNotAvailable('runtime');
     }
 
     /** @return Collection<int, string> */
@@ -69,7 +69,7 @@ class Xdg
             return collect($directories);
         }
 
-        throw XdgNotAvailableException::dataDirectoriesNotAvailable();
+        throw XdgNotAvailableException::directoriesNotAvailable('data');
     }
 
     /** @return Collection<int, string> */
@@ -79,6 +79,6 @@ class Xdg
             return collect($directories);
         }
 
-        throw XdgNotAvailableException::configDirectoriesNotAvailable();
+        throw XdgNotAvailableException::directoriesNotAvailable('config');
     }
 }


### PR DESCRIPTION
Since all exceptions use a very similar format of error messages and codes, they can be simplified into 2 exceptions (well, arguably 1).