### PR TITLE
Update to not depend on dnoegel/php-xdg-base-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ app('xdg')->getHomeDirectory();
 | Retrieve the XDG home config directory. | `getHomeConfigDirectory()` | string       |
 | Retrieve the XDG home data directory.   | `getHomeDataDirectory()`   | string       |
 | Retrieve the XDG runtime directory.     | `getRuntimeDirectory()`    | string       |
-| Retrieve all XDG data directories.      | `getDataDirectories()`     | Collection   |
 | Retrieve all XDG config directories.    | `getConfigDirectories()`   | Collection   |
+| Retrieve all XDG data directories.      | `getDataDirectories()`     | Collection   |
 
 ## Change log
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Code Coverage][ico-code-coverage]][link-code-coverage]
 [![Total Downloads][ico-downloads]][link-downloads]
 
-A Laravel adapter for the XDG Base Directory package.
+A Laravel adapter for the XDG Base Directory specification.
 
 ## Install
 

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,10 @@
 {
     "name": "owenvoke/laravel-xdg",
     "type": "library",
-    "description": "A Laravel adapter for the XDG Base Directory package.",
+    "description": "A Laravel adapter for the XDG Base Directory specification.",
     "license": "MIT",
     "require": {
         "php": "^7.4",
-        "dnoegel/php-xdg-base-dir": "^0.1.1",
         "illuminate/contracts": "^7.0",
         "illuminate/support": "^7.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,11 @@
     "require": {
         "php": "^7.4",
         "dnoegel/php-xdg-base-dir": "^0.1.1",
-        "illuminate/contracts": "^6.0|^7.0",
-        "illuminate/support": "^6.0|^7.0"
+        "illuminate/contracts": "^7.0",
+        "illuminate/support": "^7.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.6|^5.0",
+        "orchestra/testbench": "^5.0",
         "phpstan/phpstan": "^0.12.5",
         "phpunit/phpunit": "^8.0|^9.0"
     },
@@ -40,5 +40,7 @@
                 "Xdg": "OwenVoke\\LaravelXdg\\Facades\\Xdg"
             }
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,3 +2,5 @@ parameters:
   level: 8
   paths:
     - src
+  ignoreErrors:
+    - "#Cannot access offset \\'(mode|uid)\\' on array\\(0 => int, 1 => int, 2 => int, 3 => int, 4 => int, 5 => int, 6 => int, 7 => int, ...\\)\\|false.#"

--- a/src/Xdg.php
+++ b/src/Xdg.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OwenVoke\LaravelXdg;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Env;
 use Illuminate\Support\Str;
 use OwenVoke\LaravelXdg\Exceptions\XdgNotAvailableException;
 

--- a/src/Xdg.php
+++ b/src/Xdg.php
@@ -47,8 +47,12 @@ class Xdg
 
     public function getHomeConfigDirectory(): string
     {
-        if ($directory = $this->xdg->getHomeConfigDir()) {
+        if ($directory = Env::get('XDG_CONFIG_HOME')) {
             return $directory;
+        }
+
+        if ($homeDirectory = $this->getHomeDirectory()) {
+            return $homeDirectory === DIRECTORY_SEPARATOR ? "{$homeDirectory}.config" : "{$homeDirectory}/.config";
         }
 
         throw XdgNotAvailableException::homeConfigDirectoryNotAvailable();

--- a/src/Xdg.php
+++ b/src/Xdg.php
@@ -18,11 +18,11 @@ class Xdg
 
     public function getHomeDirectory(): string
     {
-        if ($directory = Env::get('HOME')) {
+        if ($directory = getenv('HOME')) {
             return $directory;
         }
 
-        if (($homeDrive = Env::get('HOMEDRIVE')) && ($homePath = Env::get('HOMEPATH'))) {
+        if (($homeDrive = getenv('HOMEDRIVE')) && ($homePath = getenv('HOMEPATH'))) {
             return "{$homeDrive}/{$homePath}";
         }
 
@@ -31,7 +31,7 @@ class Xdg
 
     public function getHomeCacheDirectory(): string
     {
-        if ($directory = Env::get('XDG_CACHE_HOME')) {
+        if ($directory = getenv('XDG_CACHE_HOME')) {
             return $directory;
         }
 
@@ -44,7 +44,7 @@ class Xdg
 
     public function getHomeConfigDirectory(): string
     {
-        if ($directory = Env::get('XDG_CONFIG_HOME')) {
+        if ($directory = getenv('XDG_CONFIG_HOME')) {
             return $directory;
         }
 
@@ -57,7 +57,7 @@ class Xdg
 
     public function getHomeDataDirectory(): string
     {
-        if ($directory = Env::get('XDG_DATA_HOME')) {
+        if ($directory = getenv('XDG_DATA_HOME')) {
             return $directory;
         }
 
@@ -70,7 +70,7 @@ class Xdg
 
     public function getRuntimeDirectory(bool $strict = true): string
     {
-        if ($directory = Env::get('XDG_RUNTIME_DIR')) {
+        if ($directory = getenv('XDG_RUNTIME_DIR')) {
             return $directory;
         }
 
@@ -84,7 +84,7 @@ class Xdg
     /** @return Collection<int, string> */
     public function getConfigDirectories(): Collection
     {
-        if ($directories = Env::get('XDG_CONFIG_DIRS', '/usr/local/share:/usr/share')) {
+        if ($directories = (getenv('XDG_CONFIG_DIRS') ?: '/usr/local/share:/usr/share')) {
             return Str::of($directories)
                 ->explode(':')
                 ->prepend($this->getHomeConfigDirectory());
@@ -96,7 +96,7 @@ class Xdg
     /** @return Collection<int, string> */
     public function getDataDirectories(): Collection
     {
-        if ($directories = Env::get('XDG_DATA_DIRS', '/etc/xdg')) {
+        if ($directories = (getenv('XDG_DATA_DIRS') ?: '/etc/xdg')) {
             return Str::of($directories)
                 ->explode(':')
                 ->prepend($this->getHomeDataDirectory());
@@ -108,7 +108,7 @@ class Xdg
     /** @link https://github.com/dnoegel/php-xdg-base-dir/blob/12f5b94710c8f5b504432d57ce353075fc434339/src/Xdg.php#L86 */
     private function getFallbackDirectory(): string
     {
-        $fallback = sys_get_temp_dir().'/'.self::RUNTIME_DIR_FALLBACK.Env::get('USER');
+        $fallback = sys_get_temp_dir().'/'.self::RUNTIME_DIR_FALLBACK.getenv('USER');
 
         $create = false;
 

--- a/src/Xdg.php
+++ b/src/Xdg.php
@@ -104,8 +104,10 @@ class Xdg
     /** @return Collection<int, string> */
     public function getConfigDirectories(): Collection
     {
-        if ($directories = $this->xdg->getConfigDirs()) {
-            return collect($directories);
+        if ($directories = Env::get('XDG_CONFIG_DIRS', '/usr/local/share:/usr/share')) {
+            return Str::of($directories)
+                ->explode(':')
+                ->prepend($this->getHomeConfigDirectory());
         }
 
         throw XdgNotAvailableException::configDirectoriesNotAvailable();

--- a/src/Xdg.php
+++ b/src/Xdg.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace OwenVoke\LaravelXdg;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Env;
+use Illuminate\Support\Str;
 use OwenVoke\LaravelXdg\Exceptions\XdgNotAvailableException;
 use XdgBaseDir\Xdg as BaseXdg;
 
@@ -19,8 +21,12 @@ class Xdg
 
     public function getHomeDirectory(): string
     {
-        if ($directory = $this->xdg->getHomeDir()) {
+        if ($directory = Env::get('HOME')) {
             return $directory;
+        }
+
+        if (($homeDrive = Env::get('HOMEDRIVE')) && ($homePath = Env::get('HOMEPATH'))) {
+            return "{$homeDrive}/{$homePath}";
         }
 
         throw XdgNotAvailableException::homeDirectoryNotAvailable();

--- a/src/Xdg.php
+++ b/src/Xdg.php
@@ -34,8 +34,12 @@ class Xdg
 
     public function getHomeCacheDirectory(): string
     {
-        if ($directory = $this->xdg->getHomeCacheDir()) {
+        if ($directory = Env::get('XDG_CACHE_HOME')) {
             return $directory;
+        }
+
+        if ($homeDirectory = $this->getHomeDirectory()) {
+            return "{$homeDirectory}/.cache";
         }
 
         throw XdgNotAvailableException::homeCacheDirectoryNotAvailable();

--- a/src/Xdg.php
+++ b/src/Xdg.php
@@ -60,8 +60,12 @@ class Xdg
 
     public function getHomeDataDirectory(): string
     {
-        if ($directory = $this->xdg->getHomeDataDir()) {
+        if ($directory = Env::get('XDG_DATA_HOME')) {
             return $directory;
+        }
+
+        if ($homeDirectory = $this->getHomeDirectory()) {
+            return "{$homeDirectory}/.local/share";
         }
 
         throw XdgNotAvailableException::homeDataDirectoryNotAvailable();

--- a/src/Xdg.php
+++ b/src/Xdg.php
@@ -92,8 +92,10 @@ class Xdg
     /** @return Collection<int, string> */
     public function getDataDirectories(): Collection
     {
-        if ($directories = $this->xdg->getDataDirs()) {
-            return collect($directories);
+        if ($directories = Env::get('XDG_DATA_DIRS', '/etc/xdg')) {
+            return Str::of($directories)
+                ->explode(':')
+                ->prepend($this->getHomeDataDirectory());
         }
 
         throw XdgNotAvailableException::dataDirectoriesNotAvailable();

--- a/src/Xdg.php
+++ b/src/Xdg.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Env;
 use Illuminate\Support\Str;
 use OwenVoke\LaravelXdg\Exceptions\XdgNotAvailableException;
-use XdgBaseDir\Xdg as BaseXdg;
 
 class Xdg
 {
@@ -16,13 +15,6 @@ class Xdg
     public const S_IRWXO = 00007;  // rwx other
     public const S_IRWXG = 00056;  // rwx group
     public const RUNTIME_DIR_FALLBACK = 'php-xdg-runtime-dir-fallback-';
-
-    private BaseXdg $xdg;
-
-    public function __construct(BaseXdg $xdg)
-    {
-        $this->xdg = $xdg;
-    }
 
     public function getHomeDirectory(): string
     {
@@ -90,18 +82,6 @@ class Xdg
     }
 
     /** @return Collection<int, string> */
-    public function getDataDirectories(): Collection
-    {
-        if ($directories = Env::get('XDG_DATA_DIRS', '/etc/xdg')) {
-            return Str::of($directories)
-                ->explode(':')
-                ->prepend($this->getHomeDataDirectory());
-        }
-
-        throw XdgNotAvailableException::dataDirectoriesNotAvailable();
-    }
-
-    /** @return Collection<int, string> */
     public function getConfigDirectories(): Collection
     {
         if ($directories = Env::get('XDG_CONFIG_DIRS', '/usr/local/share:/usr/share')) {
@@ -111,6 +91,18 @@ class Xdg
         }
 
         throw XdgNotAvailableException::configDirectoriesNotAvailable();
+    }
+
+    /** @return Collection<int, string> */
+    public function getDataDirectories(): Collection
+    {
+        if ($directories = Env::get('XDG_DATA_DIRS', '/etc/xdg')) {
+            return Str::of($directories)
+                ->explode(':')
+                ->prepend($this->getHomeDataDirectory());
+        }
+
+        throw XdgNotAvailableException::dataDirectoriesNotAvailable();
     }
 
     /** @link https://github.com/dnoegel/php-xdg-base-dir/blob/12f5b94710c8f5b504432d57ce353075fc434339/src/Xdg.php#L86 */

--- a/src/Xdg.php
+++ b/src/Xdg.php
@@ -118,7 +118,7 @@ class Xdg
 
         $stats = lstat($fallback);
 
-        # The fallback must be a directory
+        // The fallback must be a directory
         if (! $stats['mode'] & self::S_IFDIR) {
             rmdir($fallback);
             $create = true;

--- a/tests/Feature/XdgTest.php
+++ b/tests/Feature/XdgTest.php
@@ -61,10 +61,20 @@ class XdgTest extends AbstractTestCase
     }
 
     /** @test */
+    public function it_can_get_the_runtime_directory_with_fallback(): void
+    {
+        putenv('XDG_RUNTIME_DIR=');
+
+        $fallbackDirectory = sys_get_temp_dir().'/'.Xdg::RUNTIME_DIR_FALLBACK;
+
+        $this->assertSame($fallbackDirectory, $this->xdg->getRuntimeDirectory(false));
+    }
+
+    /** @test */
     public function it_throws_an_exception_on_strict_runtime_when_env_does_not_exist(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('XDG_RUNTIME_DIR was not set');
+        $this->expectExceptionMessage('Unable to get the XDG runtime directory');
 
         putenv('XDG_RUNTIME_DIR=');
 

--- a/tests/Feature/XdgTest.php
+++ b/tests/Feature/XdgTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OwenVoke\LaravelXdg\Tests\Feature;
 
+use Illuminate\Support\Env;
 use OwenVoke\LaravelXdg\Tests\AbstractTestCase;
 use OwenVoke\LaravelXdg\Xdg;
 use RuntimeException;
@@ -12,20 +13,12 @@ class XdgTest extends AbstractTestCase
 {
     private Xdg $xdg;
 
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        /** @var Xdg xdg */
-        $this->xdg = app(Xdg::class);
-    }
-
     /** @test */
     public function it_can_get_the_home_directory(): void
     {
         putenv('HOME=/fake-dir');
 
-        $this->assertSame('/fake-dir', $this->xdg->getHomeDirectory());
+        $this->assertSame('/fake-dir', $this->getXdg()->getHomeDirectory());
     }
 
     /** @test */
@@ -33,7 +26,7 @@ class XdgTest extends AbstractTestCase
     {
         putenv('XDG_CACHE_HOME=/fake-dir/.cache');
 
-        $this->assertSame('/fake-dir/.cache', $this->xdg->getHomeCacheDirectory());
+        $this->assertSame('/fake-dir/.cache', $this->getXdg()->getHomeCacheDirectory());
     }
 
     /** @test */
@@ -41,7 +34,7 @@ class XdgTest extends AbstractTestCase
     {
         putenv('XDG_CONFIG_HOME=/fake-dir/.config');
 
-        $this->assertSame('/fake-dir/.config', $this->xdg->getHomeConfigDirectory());
+        $this->assertSame('/fake-dir/.config', $this->getXdg()->getHomeConfigDirectory());
     }
 
     /** @test */
@@ -49,7 +42,7 @@ class XdgTest extends AbstractTestCase
     {
         putenv('XDG_DATA_HOME=/fake-dir/.local/share');
 
-        $this->assertSame('/fake-dir/.local/share', $this->xdg->getHomeDataDirectory());
+        $this->assertSame('/fake-dir/.local/share', $this->getXdg()->getHomeDataDirectory());
     }
 
     /** @test */
@@ -57,7 +50,7 @@ class XdgTest extends AbstractTestCase
     {
         putenv('XDG_RUNTIME_DIR=/tmp/');
 
-        $this->assertSame('/tmp/', $this->xdg->getRuntimeDirectory());
+        $this->assertSame('/tmp/', $this->getXdg()->getRuntimeDirectory());
     }
 
     /** @test */
@@ -65,9 +58,9 @@ class XdgTest extends AbstractTestCase
     {
         putenv('XDG_RUNTIME_DIR=');
 
-        $fallbackDirectory = sys_get_temp_dir().'/'.Xdg::RUNTIME_DIR_FALLBACK;
+        $fallbackDirectory = sys_get_temp_dir().'/'.Xdg::RUNTIME_DIR_FALLBACK.Env::get('USER');
 
-        $this->assertSame($fallbackDirectory, $this->xdg->getRuntimeDirectory(false));
+        $this->assertSame($fallbackDirectory, $this->getXdg()->getRuntimeDirectory(false));
     }
 
     /** @test */
@@ -78,15 +71,15 @@ class XdgTest extends AbstractTestCase
 
         putenv('XDG_RUNTIME_DIR=');
 
-        $this->xdg->getRuntimeDirectory(true);
+        $this->getXdg()->getRuntimeDirectory(true);
     }
 
     /** @test */
     public function it_can_get_the_data_directories(): void
     {
-        $directories = $this->xdg->getDataDirectories();
-
         putenv('XDG_DATA_HOME=/fake-dir/.local/share');
+
+        $directories = $this->getXdg()->getDataDirectories();
 
         $this->assertNotEmpty($directories);
         $this->assertSame('/fake-dir/.local/share', $directories->first());
@@ -95,11 +88,16 @@ class XdgTest extends AbstractTestCase
     /** @test */
     public function it_can_get_the_config_directories(): void
     {
-        $directories = $this->xdg->getConfigDirectories();
-
         putenv('XDG_CONFIG_HOME=/fake-dir/.config');
+
+        $directories = $this->getXdg()->getConfigDirectories();
 
         $this->assertNotEmpty($directories);
         $this->assertSame('/fake-dir/.config', $directories->first());
+    }
+
+    private function getXdg(): Xdg
+    {
+        return app(Xdg::class);
     }
 }

--- a/tests/Feature/XdgTest.php
+++ b/tests/Feature/XdgTest.php
@@ -11,8 +11,6 @@ use RuntimeException;
 
 class XdgTest extends AbstractTestCase
 {
-    private Xdg $xdg;
-
     /** @test */
     public function it_can_get_the_home_directory(): void
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This updates the package to no longer depend on the `dnoegel/php-xdg-base-dir` package.

## Types of changes

Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Put an `x` in all the boxes that apply:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
